### PR TITLE
Fix magma cubes and add comments

### DIFF
--- a/src/main/java/com/skycatdev/nopeacefuldespawn/NoPeacefulDespawn.java
+++ b/src/main/java/com/skycatdev/nopeacefuldespawn/NoPeacefulDespawn.java
@@ -11,6 +11,7 @@ public class NoPeacefulDespawn implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
+        LOGGER.info("No Peaceful Despawn has been initialized!");
 		NoPeacefulDespawnConfig.init();
 	}
 }

--- a/src/main/java/com/skycatdev/nopeacefuldespawn/mixin/AllowInPeacefulMixinGhostBusters.java
+++ b/src/main/java/com/skycatdev/nopeacefuldespawn/mixin/AllowInPeacefulMixinGhostBusters.java
@@ -1,23 +1,15 @@
 package com.skycatdev.nopeacefuldespawn.mixin;
 
-import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import net.minecraft.entity.EntityType;
-import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.mob.GhastEntity;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.random.Random;
 import net.minecraft.world.Difficulty;
 import net.minecraft.world.WorldAccess;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-import java.util.Objects;
-
 import static com.skycatdev.nopeacefuldespawn.NoPeacefulDespawnConfig.PEACEFUL_SPAWNERS;
-import static net.minecraft.entity.mob.MobEntity.canMobSpawn;
 
 @Mixin({GhastEntity.class} )
 public abstract class AllowInPeacefulMixinGhostBusters {

--- a/src/main/java/com/skycatdev/nopeacefuldespawn/mixin/AllowInPeacefulMixinSpicy.java
+++ b/src/main/java/com/skycatdev/nopeacefuldespawn/mixin/AllowInPeacefulMixinSpicy.java
@@ -2,7 +2,7 @@ package com.skycatdev.nopeacefuldespawn.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import net.minecraft.entity.mob.SlimeEntity;
+import net.minecraft.entity.mob.MagmaCubeEntity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.Difficulty;
 import net.minecraft.world.WorldAccess;
@@ -10,13 +10,13 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 import static com.skycatdev.nopeacefuldespawn.NoPeacefulDespawnConfig.PEACEFUL_SPAWNERS;
-//Possible vanilla bug?
-//Slimes spawn less with monster spawners;
-//Mojang's code does not seem to account for not requiring slime chunks?
-//Need more information on this...
-@Mixin({SlimeEntity.class})
-public abstract class AllowInPeacefulMixinSlimer {
-    @WrapOperation(method = "canSpawn", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldAccess;getDifficulty()Lnet/minecraft/world/Difficulty;"))
+
+@Mixin({MagmaCubeEntity.class})
+public abstract class AllowInPeacefulMixinSpicy {
+    //Why do magma cubes not use slime chunks here?
+    //canSpawn is overwritten to return default behavior of spawning.
+    //Slimes don't account for spawners in vanilla.
+    @WrapOperation(method = "canMagmaCubeSpawn", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldAccess;getDifficulty()Lnet/minecraft/world/Difficulty;"))
     private static Difficulty noPeacefulDespawn$dontDisallowSpawns(WorldAccess world, Operation<Difficulty> original) {
         Difficulty difficulty = original.call(world);
         if (difficulty == Difficulty.PEACEFUL) { // If it's not peaceful, no need to do other checks

--- a/src/main/java/com/skycatdev/nopeacefuldespawn/mixin/HostileEntityMixin.java
+++ b/src/main/java/com/skycatdev/nopeacefuldespawn/mixin/HostileEntityMixin.java
@@ -9,8 +9,6 @@ import net.minecraft.world.WorldAccess;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-import java.util.Objects;
-
 import static com.skycatdev.nopeacefuldespawn.NoPeacefulDespawnConfig.PEACEFUL_SPAWNERS;
 
 @Mixin(HostileEntity.class)

--- a/src/main/java/com/skycatdev/nopeacefuldespawn/mixin/MobSpawnerLogicMixin.java
+++ b/src/main/java/com/skycatdev/nopeacefuldespawn/mixin/MobSpawnerLogicMixin.java
@@ -11,8 +11,6 @@ import net.minecraft.world.WorldView;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-import java.util.Objects;
-
 import static com.skycatdev.nopeacefuldespawn.NoPeacefulDespawnConfig.PEACEFUL_SPAWNERS;
 
 @Mixin(MobSpawnerLogic.class)
@@ -27,7 +25,11 @@ public abstract class MobSpawnerLogicMixin {
         return difficulty;
     }
 
-    //Extra check for monsters like phantoms that do not follow rules of spawning
+    //In PhantomEntity.class it seems isDisallowedInPeaceful is typed again
+    //This is in spite of already inheriting isDisallowedInPeaceful from MobEntity.class
+    //It's more simple to wrap with this function below for people who do mod this game.
+    //Mojang should remove the extra isDisallowedInPeaceful to save function calls.
+    //If for whatever reason other community mods do not follow rules of spawning, we keep this here.
     @WrapOperation(method = "serverTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/mob/MobEntity;canSpawn(Lnet/minecraft/world/WorldView;)Z"))
     private boolean noPeacefulDespawn$respectGamerule(MobEntity instance, WorldView world, Operation<Boolean> original) {
         if (instance.getWorld().getDifficulty() == Difficulty.PEACEFUL) {

--- a/src/main/resources/no-peaceful-despawn.mixins.json
+++ b/src/main/resources/no-peaceful-despawn.mixins.json
@@ -6,6 +6,7 @@
     "AllowInPeacefulMixin",
     "AllowInPeacefulMixinGhostBusters",
     "AllowInPeacefulMixinSlimer",
+    "AllowInPeacefulMixinSpicy",
     "HostileEntityMixin",
     "MobEntityMixin",
     "MobSpawnerLogicMixin",


### PR DESCRIPTION
Do we fix vanilla bugs in an extra config?
Slimes from monster spawners check for slime chunks in vanilla, but this seems like a bug as monster spawners do not have to be in slime chunks.